### PR TITLE
Fix BBCode whitespace display

### DIFF
--- a/styles/prosilver/theme/common.css
+++ b/styles/prosilver/theme/common.css
@@ -705,6 +705,11 @@ li.row dl.codebox dd {
 	padding: 0;
 }
 
+.bbcode-container .codebox code {
+	white-space: pre-wrap;
+	tab-size: 4;
+}
+
 /* Codebox adjustments for the revision section of BBCode */
 .revision-details > .bbcode-container > .codebox {
 	min-height: 40px;


### PR DESCRIPTION
Currently, the UI renders the BBCode and HTML replacement wrapped in a `<code>` element, but no `<pre>` element, so whitespace is collapsed. This makes complex HTML less readable, and can even lead to semantic differences. For example:

```html
<script>
	console.log(1)
	console.log(2)
</script>
```

With whitespace collapsed, newlines are rendered as spaces when copying and pasting, so the two lines of JS are concatenated into one, causing a syntax error:

```html
<script> console.log(1) console.log(2) </script>
```

Another example that causes discrepancies even without semicolon-less JS:

```html
<pre onclick="this.textContent = '	tab indented'">not indented</pre>
```

A little contrived, but I'm sure there are plenty of other cases that could cause issues.

This PR fixes the problem by adding `white-space: pre-wrap` CSS to the `.codebox` elements.